### PR TITLE
Experimental support for rasterizing via PhantomJS.

### DIFF
--- a/htmlshot/app.js
+++ b/htmlshot/app.js
@@ -1,0 +1,18 @@
+var spawn = require('child_process').spawn;
+var express = require('express');
+
+var app = express();
+
+var RENDER = __dirname + '/render.js';
+var PORT = process.env.PORT || 3000;
+
+app.get('/shot', function(req, res, next) {
+  var html = (req.query.html || '').trim();
+  if (!html) return res.sendStatus(204);
+  res.type('image/png');
+  spawn(process.execPath, [RENDER, html]).stdout.pipe(res);
+});
+
+app.listen(PORT, function() {
+  console.log("listening on " + PORT);
+});

--- a/htmlshot/phantom-rasterize.js
+++ b/htmlshot/phantom-rasterize.js
@@ -1,0 +1,52 @@
+var page = require('webpage').create(),
+    system = require('system'),
+    address, output, size;
+
+if (system.args.length < 3 || system.args.length > 5) {
+    console.log('Usage: rasterize.js URL filename [paperwidth*paperheight|paperformat] [zoom]');
+    console.log('  paper (pdf output) examples: "5in*7.5in", "10cm*20cm", "A4", "Letter"');
+    console.log('  image (png/jpg output) examples: "1920px" entire page, window width 1920px');
+    console.log('                                   "800px*600px" window, clipped to 800x600');
+    phantom.exit(1);
+} else {
+    address = system.args[1];
+    output = system.args[2];
+    page.viewportSize = { width: 600, height: 600 };
+    page.settings.loadImages = true;
+    page.settings.localToRemoteUrlAccessEnabled = true;
+    page.settings.javascriptEnabled = false;
+    page.settings.webSecurityEnabled = false;
+    if (system.args.length > 3 && system.args[2].substr(-4) === ".pdf") {
+        size = system.args[3].split('*');
+        page.paperSize = size.length === 2 ? { width: size[0], height: size[1], margin: '0px' }
+                                           : { format: system.args[3], orientation: 'portrait', margin: '1cm' };
+    } else if (system.args.length > 3 && system.args[3].substr(-2) === "px") {
+        size = system.args[3].split('*');
+        if (size.length === 2) {
+            pageWidth = parseInt(size[0], 10);
+            pageHeight = parseInt(size[1], 10);
+            page.viewportSize = { width: pageWidth, height: pageHeight };
+            page.clipRect = { top: 0, left: 0, width: pageWidth, height: pageHeight };
+        } else {
+            console.log("size:", system.args[3]);
+            pageWidth = parseInt(system.args[3], 10);
+            pageHeight = parseInt(pageWidth * 3/4, 10); // it's as good an assumption as any
+            console.log ("pageHeight:",pageHeight);
+            page.viewportSize = { width: pageWidth, height: pageHeight };
+        }
+    }
+    if (system.args.length > 4) {
+        page.zoomFactor = system.args[4];
+    }
+    page.open(address, function (status) {
+        if (status !== 'success') {
+            console.log('Unable to load the address!');
+            phantom.exit(1);
+        } else {
+            window.setTimeout(function () {
+                page.render(output);
+                phantom.exit();
+            }, 2000);
+        }
+    });
+}

--- a/htmlshot/render.js
+++ b/htmlshot/render.js
@@ -1,0 +1,37 @@
+var spawn = require('child_process').spawn;
+var fs = require('fs');
+
+var PHANTOMJS = process.env.PHANTOMJS || 'phantomjs';
+var RASTERIZE = __dirname + '/phantom-rasterize.js';
+var HTML = process.argv[2];
+
+var tempBasename = 'tempshot_' + Date.now() + '_' + Math.random();
+var tempPngFilename = tempBasename + '.png';
+var tempHtmlFilename = tempBasename + '.html';
+
+//var dataURL = 'data:text/html;base64,' +
+//              (new Buffer(HTML)).toString('base64');
+
+fs.writeFileSync(tempHtmlFilename, HTML);
+
+var phantom = spawn(PHANTOMJS, [
+  RASTERIZE,
+//  dataURL,
+  tempHtmlFilename,
+  tempPngFilename,
+  '640px*480px'
+]);
+
+phantom.on('close', function(code) {
+  process.stderr.write("CODE " + code + "\n");
+  if (code) return process.exit(code);
+  fs.createReadStream(tempPngFilename).pipe(process.stdout);
+});
+
+process.on('exit', function() {
+  process.stderr.write("EXIT\n");
+  [tempPngFilename, tempHtmlFilename].forEach(function(filename) {
+    if (fs.existsSync(filename))
+      fs.unlinkSync(filename);
+  });
+});

--- a/src/export-modal.jsx
+++ b/src/export-modal.jsx
@@ -21,18 +21,24 @@ define(function(require) {
       // the textarea to readonly (which would also prevent the warning)
       // because that would prevent the text from being selectable.
     },
+    handleExportToPNG: function(e) {
+      e.preventDefault();
+      window.open('http://localhost:3000/shot?html=' +
+                  encodeURIComponent(this.props.html));
+    },
     createDataURL: function(html) {
       return 'data:text/html;base64,' + btoa(html);
     },
     render: function() {
       var html = this.prettifyHtml(this.props.html);
       return (
-        <Modal title="Export to HTML" onClose={this.props.onClose}>
+        <Modal title="Export" onClose={this.props.onClose}>
           <div className="modal-body">
             <p>Here is the HTML for your awesome thing. You can copy and paste it into an editor like <a href="https://thimble.webmaker.org" target="_blank">Thimble</a>, or open it in a <a href={this.createDataURL(html)} target="_blank">new tab</a>.</p>
             <textarea className="form-control" rows="10" style={{
               fontFamily: 'monospace'
             }} spellCheck="false" value={html} onChange={this.handleChange}></textarea>
+            <p>Alternatively, you can also download a <a href="#" onClick={this.handleExportToPNG}>PNG</a> of your awesome thing.</p>
           </div>
         </Modal>
       );


### PR DESCRIPTION
This is actually a failed experiment that I'm documenting via this pull request, which I'll immediately close after creating.

Basically, I wanted to create a super-simple implementation for generating a static image of a user's creation by delegating to PhantomJS. However, among other things, PhantomJS doesn't currently support WOFF fonts, so the rasterization looks horrible.

I guess just using an addon for rasterization might be the best option now, alas.
